### PR TITLE
Use minimum entropy for finding both single and multiple fixation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: sitePath
 Type: Package
 Title: Detection of sites with fixation of amino acid substitutions
     in protein evolution
-Version: 1.1.1
+Version: 1.1.2
 Author: Chengyang Ji, Aiping Wu
 Maintainer: Chengyang Ji <chengyang.ji12@alumni.xjtlu.edu.cn>
 Description: The package does hierarchical search for fixation events given

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+CHANGES IN VERSION 1.1.2
+-------------------------
+    o Use 'multiFixationSites' for both single and multiple fixation sites
+
+
+CHANGES IN VERSION 1.1.1
+-------------------------
+    o Bug fix: Error when adding new result in 'fixationSites'
+
+
 CHANGES IN VERSION 0.99.28
 -------------------------
     o Bug fix: Internal indexing error in 'multiFixationSites'

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -300,7 +300,7 @@ plotSingleSite.multiFixationSites <- function(x, site, ...) {
             targetEdges <- tip2Edge(tree$edge, tips, rootNode)
             color[targetEdges] <- AA_COLORS[aa]
             lty[targetEdges] <- 1
-            width[targetEdges] <- 1
+            width[targetEdges] <- 2
         }
         AAnames <- c(AAnames, aaName)
         plotName <- c(plotName, paste0(aaName, collapse = " -> "))

--- a/src/exportFunc.cpp
+++ b/src/exportFunc.cpp
@@ -152,7 +152,16 @@ Rcpp::ListOf<Rcpp::IntegerVector> minimizeEntropy(
     SearchTree<Amalgamator> dSearch(minEffectiveSize, nodeSummaries);
     dSearch.search();
     float iMin = iSearch.getMinEntropy(), dMin = dSearch.getMinEntropy();
-    segment final = (iMin < dMin) ? iSearch.getFinal() : dSearch.getFinal();
+    // segment final = (iMin < dMin) ? iSearch.getFinal() : dSearch.getFinal();
+    segment iFinal = iSearch.getFinal(), dFinal = dSearch.getFinal();
+    segment final;
+    if (iFinal.size() > dFinal.size()) {
+        final = iFinal;
+    } else if (iFinal.size() == dFinal.size()) {
+        final = (iMin < dMin) ? iSearch.getFinal() : dSearch.getFinal();
+    } else {
+        final = dFinal;
+    }
     return updatedSegmentation(nodeSummaries, final);
     // while (iSearch.getFinal() != dSearch.getFinal()) {
     //     if (iMin > dMin) {


### PR DESCRIPTION
## Using 'multiFixationSites' for both kinds of fixation

In #4 , minimum entropy was introduced for finding sites with multiple fixations and this showed the ability for finding single fixation. While the function 'fixationSites' can miss some intended sites, 'multiFixationSites' was adapted to include those sites as well.