### PR TITLE
The '.mergeClusters' strategy amendment

### DIFF
--- a/R/fixationSites.R
+++ b/R/fixationSites.R
@@ -331,11 +331,18 @@ fixationSites.lineagePath <- function(paths,
     for (gpIndex in seq_along(groupByPath)[-1]) {
         # 'gp' is the complete path with overlapped parts
         gp <- groupByPath[[gpIndex]]
+        # Set the variables to NULL for debugging
+        m <- NULL
+        d <- NULL
+        tipNum <- NULL
         # The index of 'res' which to merge with 'gp'
         toMergeIndex <- NULL
         # The index of 'gp' where the divergent point is. Each truncated 'gp' in
         # 'res' will have one but only the deepest will be used
         divergedIndex <- 0L
+        # The number of shared tips at divergent point will be used to decide if
+        # the two clusters are completely diverged or not
+        sharedAtDiv <- 0L
         # Loop through 'res' to find the most related group (because all the
         # clusters are unique, the first cluster in 'gp' cannot be found is the
         # divergent point)
@@ -348,13 +355,15 @@ fixationSites.lineagePath <- function(paths,
                 if (any(!gp[[j]] %in% allTips)) {
                     m <- i
                     d <- j
+                    tipNum <- length(intersect(gp[[j]], allTips))
                     break
                 }
             }
-            # The deepest divergent point
-            if (d > divergedIndex) {
+            # The deepest and most divergent point
+            if (d >= divergedIndex && tipNum >= sharedAtDiv) {
                 toMergeIndex <- m
                 divergedIndex <- d
+                sharedAtDiv <- tipNum
             }
         }
         # Find the tips when diverged

--- a/R/fixationSites.R
+++ b/R/fixationSites.R
@@ -331,10 +331,10 @@ fixationSites.lineagePath <- function(paths,
     for (gpIndex in seq_along(groupByPath)[-1]) {
         # 'gp' is the complete path with overlapped parts
         gp <- groupByPath[[gpIndex]]
-        # Set the variables to NULL for debugging
+        # Reset the variables to NULL for in case of no overlap
         m <- NULL
         d <- NULL
-        tipNum <- NULL
+        t <- integer()
         # The index of 'res' which to merge with 'gp'
         toMergeIndex <- NULL
         # The index of 'gp' where the divergent point is. Each truncated 'gp' in
@@ -342,7 +342,7 @@ fixationSites.lineagePath <- function(paths,
         divergedIndex <- 0L
         # The number of shared tips at divergent point will be used to decide if
         # the two clusters are completely diverged or not
-        sharedAtDiv <- 0L
+        sharedAtDiv <- integer()
         # Loop through 'res' to find the most related group (because all the
         # clusters are unique, the first cluster in 'gp' cannot be found is the
         # divergent point)
@@ -355,15 +355,17 @@ fixationSites.lineagePath <- function(paths,
                 if (any(!gp[[j]] %in% allTips)) {
                     m <- i
                     d <- j
-                    tipNum <- length(intersect(gp[[j]], allTips))
+                    t <- intersect(gp[[j]], allTips)
                     break
                 }
             }
             # The deepest and most divergent point
-            if (d >= divergedIndex && tipNum >= sharedAtDiv) {
+            if (d >= divergedIndex &&
+                length(t) >= length(sharedAtDiv) &&
+                all(t) %in% unlist(res[[m]])) {
                 toMergeIndex <- m
                 divergedIndex <- d
-                sharedAtDiv <- tipNum
+                sharedAtDiv <- t
             }
         }
         # Find the tips when diverged
@@ -399,7 +401,8 @@ fixationSites.lineagePath <- function(paths,
                 if (length(sharedTips) == 0) {
                     # There is at least one group of tips before divergence
                     attr(toMerge[[i - 1]], "toMerge") <- gpIndex
-                    attr(toMerge[[i - 1]], "toMergeRefSites") <- refSites
+                    attr(toMerge[[i - 1]], "toMergeRefSites") <-
+                        refSites
                     sharedTips <- list()
                 } else {
                     # Give back the fixation site info to the shared part

--- a/R/fixationSites.R
+++ b/R/fixationSites.R
@@ -341,22 +341,27 @@ fixationSites.lineagePath <- function(paths,
         # The number of shared tips at divergent point will be used to decide if
         # the two clusters are completely diverged or not
         sharedAtDiv <- integer()
-        # Loop through 'res' to find the most related group (because all the
-        # clusters are unique, the first cluster in 'gp' cannot be found is the
-        # divergent point)
+        # Loop through 'res' to find the most related group
         for (i in seq_along(res)) {
             # All existing tips in the other 'gp' in 'groupByPath' to see if
             # overlapped with tips in the 'gp' to be merged
             allTips <- unlist(groupByPath[[i]])
-            # The first cluster in 'gp' to have no overlap (divergent point)
+            # Because all the tip groups are unique in 'res', the first cluster
+            # in 'gp' containing tips that cannot be found is the divergent
+            # point
             for (j in seq_along(gp)) {
-                if (any(!gp[[j]] %in% allTips)) {
+                # Once a potential divergent point having being found, safeguard
+                # the truncated 'gp' (in 'res') to merge with have actual
+                # overlap with the 'gp'
+                if (any(!gp[[j]] %in% allTips) &&
+                    any(unlist(gp) %in% unlist(res[[i]]))) {
                     t <- intersect(gp[[j]], allTips)
-                    # The deepest and most divergent point, safeguard the 'gp'
-                    # has overlap with the truncated 'gp' to merge with in 'res'
-                    if (j >= divergedIndex &&
-                        length(t) >= length(sharedAtDiv) &&
-                        any(unlist(gp) %in% unlist(res[[i]]))) {
+                    # The deepest and most divergent point, which is decided by
+                    # the index. When the index is the same as the previous one,
+                    # chose the one with more shared tips
+                    if (j > divergedIndex ||
+                        (j == divergedIndex &&
+                         length(t) >= length(sharedAtDiv))) {
                         toMergeIndex <- i
                         divergedIndex <- j
                         sharedAtDiv <- t


### PR DESCRIPTION
In #10 , the new strategy of '.mergeClusters' turns out still causing error. It missed some special cases where 'NA' would appear in the cluster name.

# 1. The more divergent lineage when divergent points are the same
Sometimes, the divergent point of a path can be the same in multiple other lineages. In such case, a group of tips could get more than one merging info and only the last one would be stored. If the tree is fully solved to be bifurcated, there usually exists a more divergent lineage among them (This is debatable though as I'm write this through). To get a more divergent lineage, the one with more shared tips at the divergent point should be chosen. 

# 2. Attributes loss when tips near divergent point
It is a very common issue in the R programming language. The attribute of an object can easily be lost after certain operation. Here, it is the merging info of a group of tips which were given enough attention in #10 .

The merging issue has always been caused by non-bifurcation, this was never considered in the begining. The non-bifurcation might be allowed in the future.