### PR TITLE
Consistent fixation result among lineages

### DIFF
--- a/R/SNPsites.R
+++ b/R/SNPsites.R
@@ -40,12 +40,7 @@ SNPsites.phyMSAmatched <- function(tree, minSNP = NULL, ...) {
     align <- attr(x, "align")
     msaNumbering <- attr(x, "msaNumbering")
     refSeqName <- attr(x, "reference")
-    gapChar <- attr(x, "gapChar")
-    if (attr(x, "seqType") == "AA") {
-        unambiguous <- setdiff(AA_UNAMBIGUOUS, gapChar)
-    } else {
-        unambiguous <- setdiff(NT_UNAMBIGUOUS, gapChar)
-    }
+    unambiguous <- .unambiguousChars(x)
     # Find SNP for each tree tip by comparing with the consensus sequence or the
     # reference sequence if specified
     if (is.null(refSeqName)) {

--- a/R/SNPsites.R
+++ b/R/SNPsites.R
@@ -17,8 +17,9 @@
 #' data(zikv_align_reduced)
 #' tree <- addMSA(zikv_tree_reduced, alignment = zikv_align_reduced)
 #' SNPsites(tree)
-SNPsites <- function(tree, ...)
+SNPsites <- function(tree, ...) {
     UseMethod("SNPsites")
+}
 
 #' @rdname SNPsites
 #' @export

--- a/R/extractTips.R
+++ b/R/extractTips.R
@@ -17,8 +17,9 @@
 #' tree <- addMSA(zikv_tree_reduced, alignment = zikv_align_reduced)
 #' mutations <- fixationSites(lineagePath(tree))
 #' extractTips(mutations, 139)
-extractTips <- function(x, ...)
+extractTips <- function(x, ...) {
     UseMethod("extractTips")
+}
 
 #' @rdname extractTips
 #' @description For \code{\link{lineagePath}}, the function \code{extractTips}

--- a/R/extrractSite.R
+++ b/R/extrractSite.R
@@ -15,8 +15,9 @@
 #' tree <- addMSA(zikv_tree_reduced, alignment = zikv_align_reduced)
 #' mutations <- fixationSites(lineagePath(tree))
 #' extractSite(mutations, 139)
-extractSite <- function(x, site, ...)
+extractSite <- function(x, site, ...) {
     UseMethod("extractSite")
+}
 
 #' @rdname extractSite
 #' @export

--- a/R/fixationPath.R
+++ b/R/fixationPath.R
@@ -20,8 +20,9 @@
 #' paths <- lineagePath(tree)
 #' mutations <- fixationSites(paths)
 #' fixationPath(mutations)
-fixationPath <- function(x, ...)
+fixationPath <- function(x, ...) {
     UseMethod("fixationPath")
+}
 
 #' @rdname fixationPath
 #' @export

--- a/R/fixationSites.R
+++ b/R/fixationSites.R
@@ -25,8 +25,9 @@
 #' data(zikv_align_reduced)
 #' tree <- addMSA(zikv_tree_reduced, alignment = zikv_align_reduced)
 #' fixationSites(lineagePath(tree))
-fixationSites <- function(paths, ...)
+fixationSites <- function(paths, ...) {
     UseMethod("fixationSites")
+}
 
 #' @rdname fixationSites
 #' @export

--- a/R/fixationSites.R
+++ b/R/fixationSites.R
@@ -52,12 +52,7 @@ fixationSites.sitesMinEntropy <- function(paths, ...) {
     tree <- attr(paths, "tree")
     align <- attr(paths, "align")
     seqType <- attr(paths, "seqType")
-    gapChar <- attr(paths, "gapChar")
-    if (seqType == "AA") {
-        unambiguous <- setdiff(AA_UNAMBIGUOUS, gapChar)
-    } else {
-        unambiguous <- setdiff(NT_UNAMBIGUOUS, gapChar)
-    }
+    unambiguous <- .unambiguousChars(paths)
     # 'res' is going to be the return of this function. Each entry in the list
     # is the 'sitePath' for a site. Each site ('sitePath') consists of 'mutPath'
     # that is named by the starting node name. The fixed AA and number of

--- a/R/groupTips.R
+++ b/R/groupTips.R
@@ -20,8 +20,9 @@
 #' data(zikv_align)
 #' tree <- addMSA(zikv_tree, alignment = zikv_align)
 #' groupTips(tree)
-groupTips <- function(tree, ...)
+groupTips <- function(tree, ...) {
     UseMethod("groupTips")
+}
 
 #' @rdname groupTips
 #' @export

--- a/R/lineagePath.R
+++ b/R/lineagePath.R
@@ -23,8 +23,9 @@
 #' data('zikv_align')
 #' tree <- addMSA(zikv_tree, alignment = zikv_align)
 #' lineagePath(tree)
-lineagePath <- function(tree, similarity, ...)
+lineagePath <- function(tree, similarity, ...) {
     UseMethod("lineagePath")
+}
 
 #' @rdname lineagePath
 #' @export

--- a/R/parallelSites.R
+++ b/R/parallelSites.R
@@ -54,12 +54,7 @@ parallelSites.sitesMinEntropy <- function(x,
     paths <- attr(x, "paths")
     align <- attr(paths, "align")
     reference <- attr(paths, "msaNumbering")
-    gapChar <- attr(paths, "gapChar")
-    if (attr(paths, "seqType") == "AA") {
-        unambiguous <- setdiff(AA_UNAMBIGUOUS, gapChar)
-    } else {
-        unambiguous <- setdiff(NT_UNAMBIGUOUS, gapChar)
-    }
+    unambiguous <- .unambiguousChars(paths)
     # There must be at least two lineages to have mutations and one of the fixed
     # amino acids/nucleotides should be unambiguous
     hasParallelMut <- Reduce("+", lapply(x, function(segs) {

--- a/R/parallelSites.R
+++ b/R/parallelSites.R
@@ -26,8 +26,9 @@
 #' paths <- lineagePath(tree)
 #' x <- sitesMinEntropy(paths)
 #' parallelSites(x)
-parallelSites <- function(x, ...)
+parallelSites <- function(x, ...) {
     UseMethod("parallelSites")
+}
 
 #' @rdname parallelSites
 #' @export

--- a/R/plotMutSites.R
+++ b/R/plotMutSites.R
@@ -16,8 +16,9 @@
 #' data(zikv_align_reduced)
 #' tree <- addMSA(zikv_tree_reduced, alignment = zikv_align_reduced)
 #' plotMutSites(SNPsites(tree))
-plotMutSites <- function(x, ...)
+plotMutSites <- function(x, ...) {
     UseMethod("plotMutSites")
+}
 
 #' @rdname plotMutSites
 #' @export

--- a/R/plotSingleSite.R
+++ b/R/plotSingleSite.R
@@ -28,8 +28,9 @@
 #' tree <- addMSA(zikv_tree, alignment = zikv_align)
 #' paths <- lineagePath(tree)
 #' plotSingleSite(paths, 139)
-plotSingleSite <- function(x, site, ...)
+plotSingleSite <- function(x, site, ...) {
     UseMethod("plotSingleSite")
+}
 
 #' @rdname plotSingleSite
 #' @description For \code{\link{lineagePath}}, the tree will be colored

--- a/R/siteNumbering.R
+++ b/R/siteNumbering.R
@@ -57,11 +57,7 @@ setSiteNumbering.phyMSAmatched <- function(x,
     } else if (minSkipSize < 1 && minSkipSize > 0) {
         minSkipSize <- minSkipSize * length(align)
     }
-    if (attr(x, "seqType") == "AA") {
-        unambiguous <- setdiff(AA_UNAMBIGUOUS, gapChar)
-    } else {
-        unambiguous <- setdiff(NT_UNAMBIGUOUS, gapChar)
-    }
+    unambiguous <- .unambiguousChars(x)
     attr(x, "loci") <- which(vapply(
         X = attr(x, "msaNumbering") - 1,
         FUN = function(s) {
@@ -87,6 +83,16 @@ setSiteNumbering.phyMSAmatched <- function(x,
         FUN.VALUE = logical(1)
     ))
     return(x)
+}
+
+.unambiguousChars <- function(x) {
+    gapChar <- attr(x, "gapChar")
+    if (attr(x, "seqType") == "AA") {
+        res <- setdiff(AA_UNAMBIGUOUS, gapChar)
+    } else {
+        res <- setdiff(NT_UNAMBIGUOUS, gapChar)
+    }
+    return(res)
 }
 
 .phyMSAmatch <- function(x) {

--- a/R/siteNumbering.R
+++ b/R/siteNumbering.R
@@ -22,8 +22,9 @@
 #' msaPath <- system.file('extdata', 'ZIKV.fasta', package = 'sitePath')
 #' tree <- addMSA(zikv_tree, msaPath = msaPath, msaFormat = 'fasta')
 #' setSiteNumbering(tree)
-setSiteNumbering <- function(x, reference, gapChar, ...)
+setSiteNumbering <- function(x, reference, gapChar, ...) {
     UseMethod("setSiteNumbering")
+}
 
 #' @rdname setSiteNumbering
 #' @export

--- a/R/sitePath-deprecated.R
+++ b/R/sitePath-deprecated.R
@@ -15,8 +15,9 @@
 NULL
 
 #' @export
-multiFixationSites <- function(paths, ...)
+multiFixationSites <- function(paths, ...) {
     UseMethod("multiFixationSites")
+}
 
 #' @export
 multiFixationSites.lineagePath <- function(paths,

--- a/R/sitesMinEntropy.R
+++ b/R/sitesMinEntropy.R
@@ -22,8 +22,9 @@
 #' data(zikv_align_reduced)
 #' tree <- addMSA(zikv_tree_reduced, alignment = zikv_align_reduced)
 #' sitesMinEntropy(lineagePath(tree))
-sitesMinEntropy <- function(x, ...)
+sitesMinEntropy <- function(x, ...) {
     UseMethod("sitesMinEntropy")
+}
 
 #' @rdname sitesMinEntropy
 #' @export

--- a/tests/testthat/test-sitesMinEntropy.R
+++ b/tests/testthat/test-sitesMinEntropy.R
@@ -9,15 +9,17 @@ test_that("The return value contains correct extra info", {
     expect_true(length(p) == length(minEntropy))
     for (segs in minEntropy) {
         for (seg in segs) {
-            expect_true(all(sapply(names(seg), function(node) {
+            for (node in names(seg)) {
                 tips <- seg[[node]]
                 # The major amino acid/nucleotide should be same as the fixed
                 # and the node names should be the same
                 dominantAA <-
                     names(which.max(attr(tips, "aaSummary")))
-                dominantAA == attr(tips, "AA") &&
-                node == attr(tips, "node")
-            })))
+                if (is.null(attr(tips, "toMerge"))) {
+                    expect_true(dominantAA == attr(tips, "AA"))
+                }
+                expect_true(node == attr(tips, "node"))
+            }
         }
     }
 })


### PR DESCRIPTION
# Difference in entropy minimization result among lineages for the overlapped part  
There might be few tips difference for the same fixation event for different lieanges. Here the merging strategy introduced in #10 is used to merge the result of all lineages on the same site. This assumes the entropy minimization result of all the lineages are roughly the same for the same part. And because of the merging process, small tip cluster might be created near the root. The amino acid/nucleotide of this root group is primarily decided by the fixed amino acid/nucleotide of its original gorup. This should close #13 for now.

# Missing fixation mutation near the tree root
Because a finder lineage resovling strategy is used #19 , some fixation mutations might be missing. The small group near the root might be able to solve the issue.