### PR TITLE
Guess sequence type based on ATCG proportion

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -133,8 +133,8 @@ jobs:
           ## For textshaping, required by ragg, and required by pkgdown
           brew install harfbuzz fribidi
 
-          ## Helps compile RCurl from source
-          brew uninstall curl
+          ## For installing usethis's dependency gert
+          brew install libgit2
 
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'
@@ -161,11 +161,6 @@ jobs:
           ## https://stat.ethz.ch/pipermail/bioc-devel/2020-April/016675.html
           ## https://github.com/r-lib/remotes/issues/296
           ## Ideally, all dependencies should get installed in the first pass.
-
-          ## Temporary for now due to https://github.com/ropensci/RefManageR/issues/79
-          remotes::install_github("ropensci/bibtex")
-          remotes::install_github("ropensci/RefManageR")
-          remotes::install_github("cboettig/knitcitations")
 
           ## Pass #1 at installing dependencies
           message(paste('****', Sys.time(), 'pass number 1 at installing dependencies: local dependencies ****'))

--- a/R/addMSA.R
+++ b/R/addMSA.R
@@ -61,6 +61,19 @@ addMSA <- function(tree,
     names(align) <- alignment[["nam"]]
     attr(res, "align") <- align
     # Set the sequence type
+    if (missing(seqType)) {
+        letterSum <- table(strsplit(align[[1]], "")[[1]])
+        gapSum <- 0
+        if ("-" %in% names(letterSum)) {
+            gapSum <- letterSum[["-"]]
+        }
+        atcgSum <- sum(letterSum[c("A", "T", "C", "G")], na.rm = TRUE)
+        if (atcgSum / (sum(letterSum) - gapSum) > 0.8) {
+            seqType <- "DNA"
+        } else {
+            seqType <- "AA"
+        }
+    }
     attr(res, "seqType") <- match.arg(seqType)
     # Set 'tree' attribute
     if (!is.binary(tree)) {


### PR DESCRIPTION
When `seqType` is not specified for `addMSA` function, a single sequence is used to guess the sequence type. The `seqType` will be set to 'DNA' if more than 80% of the letters in the sequence are `A`, `T`, `C`, `G` , otherwise set to `AA` .

This will close #24 .